### PR TITLE
Improve bot spawning logic in OGServerProxy

### DIFF
--- a/lua/Mods/OGServerProxyLua/Scripts/main.lua
+++ b/lua/Mods/OGServerProxyLua/Scripts/main.lua
@@ -441,14 +441,50 @@ end
 
 -- Spawn a number of bots using different methods
 function SpawnBots(controller)
-    if BotsSpawned then return end
+    if BotsSpawned then
+        return
+    end
+
     if not controller or not controller:IsValid() then
         print("SpawnBots: controller invalid")
         return
     end
 
-    local spawned = 0
+    local world = World
+    if not world or not world:IsValid() then
+        print("SpawnBots: world invalid")
+        return
+    end
 
+    print("SpawnBots: retrieving GameMode")
+    local mode = GamePlayStatics:GetGameMode(world)
+    if mode and mode:IsValid() then
+        mode.bEnablePerfBotLogin = true
+        mode.bEnablePerfBotInPIE = true
+        mode.bIsPerfBotSpawnToRandomPosition = true
+        mode.bCanRestartPerfBot = true
+        print("SpawnBots: perf bot flags enabled")
+    else
+        print("SpawnBots: GameMode not found")
+    end
+
+    local gameInstance = GamePlayStatics:GetGameInstance(world)
+    if gameInstance and gameInstance:IsValid() then
+        for i = 1, BotsToSpawn do
+            local ok, err = pcall(function()
+                gameInstance:DebugCreatePlayer(i)
+            end)
+            if ok then
+                print("SpawnBots: DebugCreatePlayer " .. i .. " succeeded")
+            else
+                print("SpawnBots: DebugCreatePlayer " .. i .. " failed -> " .. tostring(err))
+            end
+        end
+    else
+        print("SpawnBots: GameInstance not found for DebugCreatePlayer")
+    end
+
+    local spawned = 0
     if controller.CheatManager and controller.CheatManager:IsValid() then
         for i = 1, BotsToSpawn do
             local ok, err = pcall(function()
@@ -456,8 +492,9 @@ function SpawnBots(controller)
             end)
             if ok then
                 spawned = spawned + 1
+                print("SpawnBots: spawned bot " .. i)
             else
-                print("SpawnBots: CheatManager failed on try " .. i .. " -> " .. tostring(err))
+                print("SpawnBots: CheatManager failed on bot " .. i .. " -> " .. tostring(err))
             end
         end
     else
@@ -468,8 +505,9 @@ function SpawnBots(controller)
             end)
             if ok then
                 spawned = spawned + 1
+                print("SpawnBots: spawned bot " .. i .. " via ServerCheat")
             else
-                print("SpawnBots: ServerCheat failed on try " .. i .. " -> " .. tostring(err))
+                print("SpawnBots: ServerCheat failed on bot " .. i .. " -> " .. tostring(err))
             end
         end
     end


### PR DESCRIPTION
## Summary
- allow SpawnBots to create perf bot controllers and enable perf bot settings
- log GameMode setup and DebugCreatePlayer usage
- keep automatic bot spawning when the server initializes

## Testing
- `luac -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c8352213c8325a4f589044d44f36e